### PR TITLE
自由投稿のtitle,bodyの文字数制限を変更

### DIFF
--- a/app/models/free_post.rb
+++ b/app/models/free_post.rb
@@ -1,6 +1,6 @@
 class FreePost < ApplicationRecord
     validates :title, presence: true, length: { maximum: 100 }
-    validates :body, presence: true, length: { maximum: 10}
+    validates :body, presence: true, length: { maximum: 100 }
 
     belongs_to :user, optional: true
     has_many :comments

--- a/app/models/free_post.rb
+++ b/app/models/free_post.rb
@@ -1,5 +1,5 @@
 class FreePost < ApplicationRecord
-    validates :title, presence: true, length: { maximum: 255}
+    validates :title, presence: true, length: { maximum: 100 }
     validates :body, presence: true, length: { maximum: 10}
 
     belongs_to :user, optional: true


### PR DESCRIPTION
### 概要
自由投稿のbodyの文字数の制限を変更する
### 背景・目的
文字数を無限に投稿できることを防ぐ事と現在より多く文字数と投稿してもらうため。
### 内容
- [x] free_post.rbの validates :title, presence: true, length: { maximum: 255}を
255→100に変更
- [x] free_post.rbの validates :body, presence: true, length: { maximum: 10}を
10→100に変更