### PR TITLE
情報ページのvalidate設定

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  before_action :authenticate_user!, only: %i[ new edit update destroy ]
   before_action :set_event, only: %i[ show edit update destroy ]
 
   # GET /events or /events.json


### PR DESCRIPTION
概要
イベントページにvalidateを設定しました。
確認
showメソッド以外はログインをしないと入ることができないようにしました。